### PR TITLE
Update libraries to current versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -30,12 +30,12 @@ ext {
     // Sdk and tools
     minSdkVersion = 21
     targetSdkVersion = 22
-    compileSdkVersion = 27
-    buildToolsVersion = '27.0.2'
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
 
     // App dependencies
-    supportLibraryVersion = '27.0.2'
-    designLibraryVersion = '27.0.2'
-    runtimeVersion = '100.2.0'
-    googleLocationServicesVersion = '11.6.2'
+    supportLibraryVersion = '28.0.0'
+    designLibraryVersion = '28.0.0'
+    runtimeVersion = '100.4.0'
+    googleLocationServicesVersion = '16.0.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 13 12:51:37 PST 2017
+#Tue Feb 26 12:14:51 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/nearby-app/build.gradle
+++ b/nearby-app/build.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     // App's dependencies, including test
     implementation "com.esri.arcgisruntime:arcgis-android:$rootProject.runtimeVersion"
     implementation "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"


### PR DESCRIPTION
Bumps all the library versions to the current versions. 

Target SDK is left at 22 since there are some changes that need to occur to make the app work correctly with the runtime permissions. Will handle that in a separate PR.

Addresses https://github.com/Esri/nearby-android/issues/69