### PR TITLE
Update to use ArcGIS runtime update 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 A copy of the license is available in the repository's [LICENSE](LICENSE) file.
 
-For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/guide/license-your-app.htm).
+For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment).
 
 [](Esri Tags: ArcGIS Android Mobile)
 [](Esri Language: Java)​

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 A copy of the license is available in the repository's [LICENSE](LICENSE) file.
 
-For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment).
+For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment/).
 
 [](Esri Tags: ArcGIS Android Mobile)
 [](Esri Language: Java)​

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
 # Release 1.0.10
+
 - Support for ArcGIS Runtime SDK for Android 100.10.0
 
 # Release 1.0.9

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+# Release 1.0.9
+
+- Support for ArcGIS Runtime SDK for Android 100.10.0
+
 # Release 1.0.8
 
 - Updates project to favor the use of secured `https` rather than `http`

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,6 @@ ext {
     materialLibraryVersion = '1.2.1'
     recyclerviewLibraryVersion = '1.1.0'
     legacyLibraryVersion = '1.0.0'
-    runtimeVersion = '100.10.0-2977'
+    runtimeVersion = '100.10.0'
     googleLocationServicesVersion = '17.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -35,7 +35,7 @@ ext {
     // App dependencies
     appcompatLibraryVersion = '1.2.0'
     cardviewLibraryVersion = '1.0.0'
-    materialLibraryVersion = '1.2.1'
+    materialLibraryVersion = '1.3.0'
     recyclerviewLibraryVersion = '1.1.0'
     legacyLibraryVersion = '1.0.0'
     runtimeVersion = '100.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -28,17 +28,16 @@ task clean(type: Delete) {
 // Define versions in a single place
 ext {
     // Sdk and tools
-    minSdkVersion = 21
+    minSdkVersion = 23
     targetSdkVersion = 29
     compileSdkVersion = 29
-    buildToolsVersion = '28.0.3'
 
     // App dependencies
-    appcompatLibraryVersion = '1.1.0'
+    appcompatLibraryVersion = '1.2.0'
     cardviewLibraryVersion = '1.0.0'
-    materialLibraryVersion = '1.0.0'
+    materialLibraryVersion = '1.2.1'
     recyclerviewLibraryVersion = '1.1.0'
     legacyLibraryVersion = '1.0.0'
-    runtimeVersion = '100.9.0'
-    googleLocationServicesVersion = '17.0.0'
+    runtimeVersion = '100.10.0-2977'
+    googleLocationServicesVersion = '17.1.0'
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ The example application is open source and available on GitHub. You can modify i
 
 ### Device location
 
-Nearby Places uses a [mapless app pattern](https://developers.arcgis.com/android/guide/determine-your-app-map-pattern.htm#ESRI_SECTION1_58C46384E3484890A47629F8F12E6EF5) by first presenting a list of nearby places.  Since the app starts with a list, rather than a map, the device location is obtained using Google’s Location Services API. In the future, the Runtime SDK can be used to obtain the device location outside of the `MapView`.  Before trying to obtain the device location, the app checks that the device's GPS and wireless settings are turned on and then configures Google's location service.
+Nearby Places uses a mapless app pattern by first presenting a list of nearby places.  Since the app starts with a list, rather than a map, the device location is obtained using Google’s Location Services API. In the future, the Runtime SDK can be used to obtain the device location outside of the `MapView`.  Before trying to obtain the device location, the app checks that the device's GPS and wireless settings are turned on and then configures Google's location service.
 
 ```java
 // Google's location services are configured in the

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 26 12:14:51 PST 2019
+#Tue Nov 24 17:58:24 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/nearby-app/build.gradle
+++ b/nearby-app/build.gradle
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         debug {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguardTest-rules.pro'
         }

--- a/nearby-app/build.gradle
+++ b/nearby-app/build.gradle
@@ -9,29 +9,20 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0.8"
-
-        // Enabling multidex support.
-        multiDexEnabled true
-
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         debug {
-            // Disable minifier until build tools 2.2 is out due to bug in proguard file parser.
-            minifyEnabled false
-            // Uses new built-in shrinker http://tools.android.com/tech-docs/new-build-system/built-in-shrinker
-            useProguard false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguardTest-rules.pro'
         }
         release {
             minifyEnabled true
-            useProguard true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguardTest-rules.pro'
         }
     }
-
 
     // Always show the result of every unit test, even if it passes.
     testOptions.unitTests.all {


### PR DESCRIPTION
- Android Gradle Plugin Version - 4.1.2
- Min SDK - 23 required by ArcGIS runtime
- ArcGIS runtime version - 100.10.0
- googleLocationServicesVersion - 17.1.0
- materialLibraryVersion
- appcompatLibraryVersion.       

- remove explicit addition of multiDex support (not needed with min sdk version 23)
>If your minSdkVersion is set to 21 or higher, multidex is enabled by default and you do not need the multidex library
https://developer.android.com/studio/build/multidex.html#mdex-gradle
- remove useProguard (not needed with android tools version > 3.5)
https://developer.android.com/studio/build/shrink-code.html#enable